### PR TITLE
fix closing channel

### DIFF
--- a/lirc/client.go
+++ b/lirc/client.go
@@ -181,7 +181,6 @@ func (cli *Client) SendStop(remote string, code string) (err error) {
 func (cli *Client) Close() error {
 	cli.Lock()
 	defer cli.Unlock()
-
-	close(cli.reply)
+	defer close(cli.reply)
 	return cli.conn.Close()
 }


### PR DESCRIPTION
`close(cli.reply)` に万が一失敗した場合に
`cli.conn.Close()` が実行されない問題の修正。